### PR TITLE
Update Apollo Server v3 EOL date

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -2,7 +2,7 @@
 title: Introduction to Apollo Server
 ---
 
-> ⚠️ As of 15 November 2022, Apollo Server 3 is officially deprecated, with end-of-life scheduled for 22 October 2023.
+> ⚠️ As of 15 November 2022, Apollo Server 3 is officially deprecated, with end-of-life scheduled for 22 October 2024.
 >
 >[Learn more about deprecation and end-of-life.](/apollo-server/previous-versions)
 


### PR DESCRIPTION
A blog post on August 15th, 2023, stated that the EOL date had been extended one year.

- https://www.apollographql.com/blog/announcement/backend/apollo-server-3-end-of-life-extension/